### PR TITLE
Help setup find Numpy headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,22 @@
-from distutils.core import setup
-from distutils.extension import Extension
+import logging
+
 from Cython.Distutils import build_ext
+from setuptools import setup
+from distutils.extension import Extension
+
+logging.basicConfig()
+log = logging.getLogger()
+
+include_dirs = []
+
+try:
+    import numpy
+    include_dirs.append(numpy.get_include())
+except ImportError:
+    log.critical(
+        "Numpy and its headers are required to run setup(). Exiting.")
+    sys.exit(1)
+
 setup(
     name="jenks",
     version="1.0",
@@ -11,5 +27,6 @@ setup(
     keywords="gis geospatial geographic statistics numpy cython choropleth",
     url="https://github.com/perrygeo/jenks",
     cmdclass={'build_ext': build_ext},
-    ext_modules = [Extension("jenks", ["jenks.pyx"])]
+    ext_modules = [
+        Extension("jenks", ["jenks.pyx"], include_dirs=include_dirs)]
 )

--- a/test.py
+++ b/test.py
@@ -1,5 +1,0 @@
-import json
-from jenks import jenks
-
-if __name__ == "__main__":
-    jenks(json.load(open('test.json')), 5)

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,12 @@
+import json
+from jenks import jenks
+
+def test_json():
+    data = json.load(open('test.json'))
+    breaks = jenks(data, 5)
+    assert [round(v, 6) for v in breaks] == [0.002811,
+                                             2.093548,
+                                             4.205495,
+                                             6.178148,
+                                             8.091759,
+                                             9.997983]


### PR DESCRIPTION
Also add a real test (for pytest). Run `py.test tests.py` in the repo. File name changed to align with https://pytest.org/latest/goodpractises.html#goodpractises.

Setuptool's setup() is better than the one in distutils these days and if you have pip, you have setuptools. See http://python-packaging-user-guide.readthedocs.org/en/latest/tutorial.html#creating-your-own-project.

This is a project I'll be using a lot and I look forward to contributing to it.
