### PR TITLE
Add Numpy to setup's install_requires.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Yep that's *118X faster* for just a little bit of static typing and using arrays
 The only cost is that you need Cython and a C compiler to get it working. 
 
 ```
-sudo apt-get install cython build-essential
+sudo apt-get install build-essential cython python-numpy
 pip install -e "git+https://github.com/perrygeo/jenks.git#egg=jenks"
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+Cython==0.20
+Numpy==1.8.0
+pytest
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     license="BSD",
     keywords="gis geospatial geographic statistics numpy cython choropleth",
     url="https://github.com/perrygeo/jenks",
+    install_requires=['Numpy'],
     cmdclass={'build_ext': build_ext},
     ext_modules = [
         Extension("jenks", ["jenks.pyx"], include_dirs=include_dirs)]


### PR DESCRIPTION
Show how to get python-numpy with apt and add a requirements-dev.txt
that others can use to satisfy pre-install dependencies using
`pip install -r requirements-dev.txt`.
