### PR TITLE
make setup.py better handle Cython not available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,15 @@
 import logging
 import sys
 
-from Cython.Distutils import build_ext
+try:
+    import Cython
+except ImportError:
+    log.critical(
+        "Cython is required to run setup(). Exiting.")
+    sys.exit(1)
+else:
+    from Cython.Distutils import build_ext
+
 from setuptools import setup
 from distutils.extension import Extension
 


### PR DESCRIPTION
Similarly to how it already checks that `numpy` is available,
check whether `Cython` is available, an if not emit a proper error
message and exit.