### PR TITLE
Fixed out of order logging definition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 import logging
 import sys
 
+logging.basicConfig()
+log = logging.getLogger()
+
 try:
     import Cython
 except ImportError:
@@ -12,9 +15,6 @@ else:
 
 from setuptools import setup
 from distutils.extension import Extension
-
-logging.basicConfig()
-log = logging.getLogger()
 
 include_dirs = []
 


### PR DESCRIPTION
If Cython can't be imported, the attempt to log will fail because the log object hasn't been defined yet.