### PR TITLE
loading numpy during build - not before

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 src/*
 *.c
 *.so
+/*.egg-info
+/build
+/dist
+
+/.idea/

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,33 @@
-import logging
+from distutils.core import setup
+from setuptools import Extension
 import sys
+import logging
 
 logging.basicConfig()
 log = logging.getLogger()
 
 try:
-    import Cython
-except ImportError:
-    log.critical(
-        "Cython is required to run setup(). Exiting.")
-    sys.exit(1)
-else:
     from Cython.Distutils import build_ext
-
-from setuptools import setup
-from distutils.extension import Extension
-
-include_dirs = []
-
-try:
-    import numpy
-    include_dirs.append(numpy.get_include())
+    ext_modules = [Extension("jenks", ["jenks.pyx"])]
 except ImportError:
-    log.critical(
-        "Numpy and its headers are required to run setup(). Exiting.")
-    sys.exit(1)
+    from setuptools.command.build_ext import build_ext
+    ext_modules = [Extension("jenks", ["jenks.c"])]
+
+
+class CustomBuildExtCommand(build_ext):
+    """build_ext command for use when numpy headers are needed."""
+    def run(self):
+        # Import numpy here, only when headers are needed
+        try:
+            import numpy
+        except ImportError:
+            log.critical("Numpy is required to run setup(). Exiting.")
+            sys.exit(1)
+        # Add numpy headers to include_dirs
+        self.include_dirs.append(numpy.get_include())
+        # Call original build_ext command
+        build_ext.run(self)
+
 
 setup(
     name="jenks",
@@ -35,8 +38,8 @@ setup(
     license="BSD",
     keywords="gis geospatial geographic statistics numpy cython choropleth",
     url="https://github.com/perrygeo/jenks",
-    install_requires=['Numpy'],
-    cmdclass={'build_ext': build_ext},
-    ext_modules = [
-        Extension("jenks", ["jenks.pyx"], include_dirs=include_dirs)]
+    install_requires=['numpy', 'cython'],
+    setup_requires=['numpy', 'cython'],
+    cmdclass={'build_ext': CustomBuildExtCommand},
+    ext_modules=ext_modules
 )


### PR DESCRIPTION
- if cython and numpy are not installed in the system, the setup script terminates with an error before starting the build process. This is not desirable when the package needs to be added as a requirement for other projects, especially if the installation process has to be automated (e.g., in CI)
- numpy is now imported when the extension is built, not before

note that automatic installation of dependencies works with pip but not with python setup.py install

references:

[1] https://stackoverflow.com/questions/2379898/
[2] https://stackoverflow.com/questions/4505747/